### PR TITLE
backend: separate out the auth module

### DIFF
--- a/backend/.sqlx/query-0ac9a4372e3b224f1e6ea2862128118b130d13aafb0ee16da9b52aa51858132c.json
+++ b/backend/.sqlx/query-0ac9a4372e3b224f1e6ea2862128118b130d13aafb0ee16da9b52aa51858132c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            UPDATE comments\n            SET \n                entity_id = $2,\n                author = $3,\n                text = $4,\n                data = $5,\n                moderated = $6,\n                version = $7\n            WHERE id = $1\n            RETURNING id, entity_id, author, text, data, created_at, updated_at, moderated, version\n            ",
+  "query": "\n            WITH inserted AS (\n                UPDATE comments\n                SET \n                    entity_id = $2,\n                    author = $3,\n                    text = $4,\n                    data = $5,\n                    moderated = $6,\n                    version = $7\n                WHERE id = $1\n                RETURNING *\n            )\n            SELECT i.id, i.entity_id, i.author, i.text, i.data, i.created_at, i.updated_at, i.moderated, i.version, \n                e.display_name as entity_display_name, e.category_id \n            FROM inserted i\n            JOIN entities e \n            ON e.id = entity_id\n            ",
   "describe": {
     "columns": [
       {
@@ -47,6 +47,16 @@
         "ordinal": 8,
         "name": "version",
         "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "entity_display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "category_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
@@ -69,8 +79,10 @@
       false,
       false,
       false,
+      false,
+      false,
       false
     ]
   },
-  "hash": "19ca3288d7d6d0e07f0788910a6f1f0edae75cb6deb692b900dd3c88f403e72e"
+  "hash": "0ac9a4372e3b224f1e6ea2862128118b130d13aafb0ee16da9b52aa51858132c"
 }

--- a/backend/.sqlx/query-45d4a034f7e5bc3c5e2d8be72e29306a8ca8086b4f01b0761071a3657ef01139.json
+++ b/backend/.sqlx/query-45d4a034f7e5bc3c5e2d8be72e29306a8ca8086b4f01b0761071a3657ef01139.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT id, entity_id, author, text, data, created_at, updated_at, moderated, version\n            FROM comments \n            WHERE entity_id = $1\n            ORDER BY created_at\n            ",
+  "query": "\n            WITH inserted AS (\n                INSERT INTO comments (entity_id, author, text, data, moderated)\n                VALUES ($1, $2, $3, $4, $5)\n                RETURNING *\n            )\n            SELECT i.id, i.entity_id, i.author, i.text, i.data, i.created_at, i.updated_at, i.moderated, i.version, \n                display_name as entity_display_name, category_id \n            FROM inserted i\n            JOIN entities e \n            ON e.id = entity_id\n            ",
   "describe": {
     "columns": [
       {
@@ -47,11 +47,25 @@
         "ordinal": 8,
         "name": "version",
         "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "entity_display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "category_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Bool"
       ]
     },
     "nullable": [
@@ -63,8 +77,10 @@
       false,
       false,
       false,
+      false,
+      false,
       false
     ]
   },
-  "hash": "68339e8f64ae7d0bcf6c1d3765eae0bbfd845e47e19d6a7928fbda8ebf38a2f9"
+  "hash": "45d4a034f7e5bc3c5e2d8be72e29306a8ca8086b4f01b0761071a3657ef01139"
 }

--- a/backend/.sqlx/query-60ab13c4272c0a0303351fe03c98704a09a91c421dca369b8c4c0535a083ddf5.json
+++ b/backend/.sqlx/query-60ab13c4272c0a0303351fe03c98704a09a91c421dca369b8c4c0535a083ddf5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT id, entity_id, author, text, data, created_at, updated_at, moderated, version\n            FROM comments\n            WHERE id = $1\n            ",
+  "query": "\n            SELECT c.id, c.entity_id, c.author, c.text, c.data, c.created_at, c.updated_at, c.moderated, c.version,\n                e.display_name as entity_display_name, e.category_id\n            FROM comments c\n            JOIN entities e ON e.id = c.entity_id\n            WHERE entity_id = $1\n            ORDER BY created_at\n            ",
   "describe": {
     "columns": [
       {
@@ -47,6 +47,16 @@
         "ordinal": 8,
         "name": "version",
         "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "entity_display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "category_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
@@ -63,8 +73,10 @@
       false,
       false,
       false,
+      false,
+      false,
       false
     ]
   },
-  "hash": "d1eac1ba815936c35dc0a29921f95de5274b05591aa83ac9d1dc376cf72efdc2"
+  "hash": "60ab13c4272c0a0303351fe03c98704a09a91c421dca369b8c4c0535a083ddf5"
 }

--- a/backend/.sqlx/query-7a87abadc4dbddc100efd70dce1e966dedd113a6b393de7e3ab0a8c7f8f47626.json
+++ b/backend/.sqlx/query-7a87abadc4dbddc100efd70dce1e966dedd113a6b393de7e3ab0a8c7f8f47626.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT e.id, e.display_name, e.category_id, e.created_at, e.hidden,\n                    e.moderated, e.updated_at,\n                    COALESCE(\n                        (SELECT array_agg(t.tag_id) FROM entity_tags t WHERE t.entity_id = e.id), \n                        array[]::uuid[]\n                    ) as \"tags!\"\n                FROM entities e\n                INNER JOIN entities_entities ee ON e.id = ee.parent_id\n                WHERE ee.child_id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "category_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 4,
+        "name": "hidden",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "moderated",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 7,
+        "name": "tags!",
+        "type_info": "UuidArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "7a87abadc4dbddc100efd70dce1e966dedd113a6b393de7e3ab0a8c7f8f47626"
+}

--- a/backend/.sqlx/query-92732dac31495d20b6cd7d10fc9ccd722999e5ffc1d11d2c7ddad4df7b51e7c3.json
+++ b/backend/.sqlx/query-92732dac31495d20b6cd7d10fc9ccd722999e5ffc1d11d2c7ddad4df7b51e7c3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT e.id, e.display_name, e.category_id, e.created_at, e.hidden,\n                    e.moderation_notes, e.moderated, e.updated_at,\n                    COALESCE(\n                        (SELECT array_agg(t.tag_id) FROM entity_tags t WHERE t.entity_id = e.id), \n                        array[]::uuid[]\n                    ) as \"tags!\"\n            FROM entities e\n            WHERE NOT e.moderated\n            ORDER BY created_at\n            ",
+  "query": "\n            SELECT e.id, e.display_name, e.category_id, e.created_at, e.hidden,\n                    e.moderated, e.updated_at,\n                    COALESCE(\n                        (SELECT array_agg(t.tag_id) FROM entity_tags t WHERE t.entity_id = e.id), \n                        array[]::uuid[]\n                    ) as \"tags!\"\n            FROM entities e\n            WHERE NOT e.moderated\n            ORDER BY created_at\n            ",
   "describe": {
     "columns": [
       {
@@ -30,21 +30,16 @@
       },
       {
         "ordinal": 5,
-        "name": "moderation_notes",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 6,
         "name": "moderated",
         "type_info": "Bool"
       },
       {
-        "ordinal": 7,
+        "ordinal": 6,
         "name": "updated_at",
         "type_info": "Timestamp"
       },
       {
-        "ordinal": 8,
+        "ordinal": 7,
         "name": "tags!",
         "type_info": "UuidArray"
       }
@@ -58,11 +53,10 @@
       false,
       false,
       false,
-      true,
       false,
       false,
       null
     ]
   },
-  "hash": "e60a2c57ffc6d13fc8a9e9ad4a19c8f28054bc34dee98b990e6e694e5a3212fa"
+  "hash": "92732dac31495d20b6cd7d10fc9ccd722999e5ffc1d11d2c7ddad4df7b51e7c3"
 }

--- a/backend/.sqlx/query-e3283e3ec47d6e41137df2e1546a381d7423de3099703efcdf9a9b6baebef6cc.json
+++ b/backend/.sqlx/query-e3283e3ec47d6e41137df2e1546a381d7423de3099703efcdf9a9b6baebef6cc.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO comments (entity_id, author, text, data, moderated)\n            VALUES ($1, $2, $3, $4, $5)\n            RETURNING id, entity_id, author, text, data, created_at, updated_at, moderated, version\n            ",
+  "query": "\n            SELECT c.id, c.entity_id, c.author, c.text, c.data, c.created_at, c.updated_at, c.moderated, c.version,\n                e.display_name as entity_display_name, e.category_id\n            FROM comments c\n            JOIN entities e ON e.id = c.entity_id\n            WHERE c.id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -47,15 +47,21 @@
         "ordinal": 8,
         "name": "version",
         "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "entity_display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "category_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text",
-        "Text",
-        "Jsonb",
-        "Bool"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -67,8 +73,10 @@
       false,
       false,
       false,
+      false,
+      false,
       false
     ]
   },
-  "hash": "63459e0715aec65cb83e93dc0b45bc840ec6266f78d66861edbc33ba3921d522"
+  "hash": "e3283e3ec47d6e41137df2e1546a381d7423de3099703efcdf9a9b6baebef6cc"
 }

--- a/backend/.sqlx/query-fa677201f50027889f9efd84a8707e4611a5e957f8f547e01f26ea0280ee41a5.json
+++ b/backend/.sqlx/query-fa677201f50027889f9efd84a8707e4611a5e957f8f547e01f26ea0280ee41a5.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT e.id, e.display_name, e.category_id, e.created_at, e.hidden,\n                    e.moderated, e.updated_at,\n                    COALESCE(\n                        (SELECT array_agg(t.tag_id) FROM entity_tags t WHERE t.entity_id = e.id), \n                        array[]::uuid[]\n                    ) as \"tags!\"\n                FROM entities e\n                INNER JOIN entities_entities ee ON e.id = ee.child_id\n                WHERE ee.parent_id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "category_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 4,
+        "name": "hidden",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "moderated",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 7,
+        "name": "tags!",
+        "type_info": "UuidArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "fa677201f50027889f9efd84a8707e4611a5e957f8f547e01f26ea0280ee41a5"
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1941,6 +1941,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sqlx",
+ "time",
  "tokio",
  "tower-http",
  "tracing",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ serde_with = "3.8"
 rand = "0.8.5"
 uuid = { version = "1.8", features = ["serde", "v4"] }
 scrypt = "0.11"
+time = "0.3.36"
 chrono = { version = "0.4", features = ["serde"] }
 axum = { version = "0.7", features = ["macros", "multipart"] }
 axum-extra = { version = "0.9", features = ["typed-header", "cookie"] }

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -109,7 +109,7 @@ impl AppState {
         *dyn_config = SafeHavenOptions::load(conn).await;
     }
 
-    pub fn generate_token<T>(&self, claims: T) -> String
+    pub fn generate_refresh_token<T>(&self, claims: T) -> String
     where
         T: serde::Serialize,
     {

--- a/backend/src/api/admin/auth.rs
+++ b/backend/src/api/admin/auth.rs
@@ -1,0 +1,227 @@
+use crate::api::{AppError, AppState, DbConn};
+use crate::models::user::User;
+use axum::async_trait;
+use axum::extract::{FromRequestParts, Request, State};
+use axum::http::request::Parts;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum_extra::extract::cookie::{Cookie, CookieJar, Expiration, SameSite};
+use chrono::{TimeDelta, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+// Consts
+const EPHEMERAL_TOKEN_COOKIE_NAME: &str = "ephemeral_token";
+const REFRESH_TOKEN_COOKIE_NAME: &str = "refresh_token";
+
+const REFRESH_TOKEN_MAX_INACTIVE_DAYS: i64 = 3;
+const REFRESH_TOKEN_MAX_INACTIVE_DAYS_REMEMBER_ME: i64 = 31;
+
+#[derive(Clone, Serialize, ToSchema)]
+pub struct AdminUserIdentity {
+    pub admin_id: Uuid,
+    pub username: String,
+    pub is_admin: bool,
+}
+
+impl AdminUserIdentity {
+    fn from_claims(claims: &AdminEphemeralTokenClaims) -> Self {
+        Self {
+            admin_id: claims.admin_id,
+            username: claims.username.clone(),
+            is_admin: claims.is_admin,
+        }
+    }
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for AdminUserIdentity
+where
+    S: Send + Sync,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        // Extract the claims from the request extensions
+        let claims = parts
+            .extensions
+            .get::<AdminUserIdentity>()
+            .ok_or(AppError::Unauthorized)?;
+
+        Ok(claims.clone())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+struct AdminEphemeralTokenClaims {
+    admin_id: Uuid,
+    username: String,
+    is_admin: bool,
+    exp: usize,
+    iat: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AdminRefreshTokenClaims {
+    pub admin_id: Uuid,
+    pub remember_me: bool,
+    pub exp: usize,
+    pub iat: usize,
+}
+
+pub async fn authentication_middleware(
+    State(app_state): State<AppState>,
+    DbConn(mut conn): DbConn,
+    cookies: CookieJar,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, Response> {
+    // Get the token from the cookies
+    let token = cookies
+        .get(EPHEMERAL_TOKEN_COOKIE_NAME)
+        .ok_or_else(|| AppError::Unauthorized.into_response())?
+        .value();
+
+    // 1) Decode the ephemeral token:
+    //   - If valid, continue on
+    //   - If invalid,
+    //    If
+
+    // Decode the ephemeral token
+    let token_data = jsonwebtoken::decode::<AdminEphemeralTokenClaims>(
+        token,
+        &jsonwebtoken::DecodingKey::from_secret(app_state.config.token_secret.as_ref()),
+        &jsonwebtoken::Validation::default(),
+    );
+
+    let (ephemeral_claims, update_cookie) = match token_data {
+        // If the token is valid we just return the claims
+        Ok(data) => (data.claims, false),
+
+        // If the ephemeral token is invalid try to use the refresh token to generate a new one
+        Err(_) => {
+            // get the refresh token
+            let refresh_token = cookies
+                .get(REFRESH_TOKEN_COOKIE_NAME)
+                .ok_or_else(|| AppError::Unauthorized.into_response())?
+                .value();
+
+            // decode and validate refresh token claims
+            let Ok(jsonwebtoken::TokenData { claims, .. }) =
+                jsonwebtoken::decode::<AdminRefreshTokenClaims>(
+                    refresh_token,
+                    &jsonwebtoken::DecodingKey::from_secret(app_state.config.token_secret.as_ref()),
+                    &jsonwebtoken::Validation::default(),
+                )
+            else {
+                // If the refresh token is invalid return an error
+                let purged_jar = expire_cookies(cookies);
+                return Ok((purged_jar, AppError::Unauthorized).into_response());
+            };
+
+            // get the user and create corresponding claims
+            match User::get(claims.admin_id, &mut conn).await {
+                Ok(user) => {
+                    let new_ephemeral_claims = create_user_claim(&user);
+                    (new_ephemeral_claims, true)
+                }
+                // if the user is not found, clear the cookie jar
+                Err(AppError::Database(sqlx::Error::RowNotFound)) => {
+                    let purged_jar = expire_cookies(cookies);
+                    return Ok((purged_jar, AppError::Unauthorized).into_response());
+                }
+                Err(err) => return Err(err.into_response()),
+            }
+        }
+    };
+
+    // put the token claims in the request
+    request
+        .extensions_mut()
+        .insert(AdminUserIdentity::from_claims(&ephemeral_claims));
+
+    // Execute the chain
+    let response = next.run(request).await;
+
+    Ok(if update_cookie {
+        // If a new ephemerala token is generated we need to send it back to the client
+        let ephemeral_cookie = create_ephemeral_cookie(ephemeral_claims, &app_state);
+        let new_cookies = cookies.add(ephemeral_cookie);
+        (new_cookies, response).into_response()
+    } else {
+        // Otherwise just return the response
+        response
+    })
+}
+
+pub fn expire_cookies(cookies: CookieJar) -> CookieJar {
+    cookies
+        .remove(EPHEMERAL_TOKEN_COOKIE_NAME)
+        .remove(REFRESH_TOKEN_COOKIE_NAME)
+}
+
+fn create_user_claim(user: &User) -> AdminEphemeralTokenClaims {
+    AdminEphemeralTokenClaims {
+        admin_id: user.id,
+        username: user.name.clone(),
+        is_admin: user.is_admin,
+        iat: Utc::now().timestamp() as usize,
+        exp: (Utc::now() + TimeDelta::hours(1)).timestamp() as usize,
+    }
+}
+
+fn create_ephemeral_cookie<'a>(
+    claims: AdminEphemeralTokenClaims,
+    app_state: &AppState,
+) -> Cookie<'a> {
+    let token = app_state.generate_refresh_token(claims);
+
+    Cookie::build((EPHEMERAL_TOKEN_COOKIE_NAME, token))
+        .path("/api/admin/")
+        .secure(app_state.config.secure_cookie)
+        .http_only(true)
+        .same_site(SameSite::Strict)
+        .build()
+}
+
+fn create_refresh_cookie<'a>(user_id: Uuid, app_state: &AppState, remember_me: bool) -> Cookie<'a> {
+    // sadly, the cookie library uses `time` and the jwt library uses `chrono`
+    let inactive_days = if remember_me {
+        REFRESH_TOKEN_MAX_INACTIVE_DAYS_REMEMBER_ME
+    } else {
+        REFRESH_TOKEN_MAX_INACTIVE_DAYS
+    };
+    let time_now = time::OffsetDateTime::now_utc();
+    let token_exp = time_now + time::Duration::days(inactive_days);
+
+    let token = app_state.generate_refresh_token(AdminRefreshTokenClaims {
+        admin_id: user_id,
+        iat: time_now.unix_timestamp() as usize,
+        exp: token_exp.unix_timestamp() as usize,
+        remember_me,
+    });
+
+    Cookie::build((REFRESH_TOKEN_COOKIE_NAME, token))
+        .path("/api/admin/")
+        .secure(app_state.config.secure_cookie)
+        .http_only(true)
+        .same_site(SameSite::Strict)
+        .expires(if remember_me {
+            Expiration::DateTime(time_now + time::Duration::days(inactive_days))
+        } else {
+            Expiration::Session
+        })
+        .build()
+}
+
+pub fn login(
+    app_state: &AppState,
+    cookies: CookieJar,
+    auth_user: &User,
+    remember_me: bool,
+) -> CookieJar {
+    let auth_cookie = create_ephemeral_cookie(create_user_claim(auth_user), app_state);
+    let refresh_cookie = create_refresh_cookie(auth_user.id, app_state, remember_me);
+    cookies.add(auth_cookie).add(refresh_cookie)
+}

--- a/backend/src/api/admin/entities.rs
+++ b/backend/src/api/admin/entities.rs
@@ -157,8 +157,8 @@ pub async fn admin_entity_get(
         version: admin_entity.version,
         created_at: admin_entity.created_at,
         updated_at: admin_entity.updated_at,
-        parents: parents,
-        children: children,
+        parents,
+        children,
     };
     // Return the recomposed entity
     Ok(AppJson(admin_entity_with_relations))

--- a/backend/src/api/admin/families.rs
+++ b/backend/src/api/admin/families.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::AdminUserTokenClaims;
+use super::AdminUserIdentity;
 
 #[utoipa::path(
     get,
@@ -38,11 +38,11 @@ pub async fn admin_families_list(
     )
 )]
 pub async fn admin_family_new(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Json(new_family): Json<NewOrUpdateFamily>,
 ) -> Result<AppJson<Family>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -82,12 +82,12 @@ pub async fn admin_family_get(
     )
 )]
 pub async fn admin_family_update(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
     Json(new_family): Json<NewOrUpdateFamily>,
 ) -> Result<AppJson<Family>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -108,12 +108,12 @@ pub async fn admin_family_update(
     )
 )]
 pub async fn admin_family_update_icon(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
     mut multipart: Multipart,
 ) -> Result<(), AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -151,11 +151,11 @@ pub async fn admin_family_update_icon(
     )
 )]
 pub async fn admin_family_delete(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
 ) -> Result<AppJson<()>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -176,11 +176,11 @@ pub async fn admin_family_delete(
     )
 )]
 pub async fn admin_family_delete_icon(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
 ) -> Result<AppJson<()>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 

--- a/backend/src/api/admin/options.rs
+++ b/backend/src/api/admin/options.rs
@@ -5,7 +5,7 @@ use crate::{
     models::options::{ConfigurationOption, SafeHavenOptions},
 };
 
-use super::AdminUserTokenClaims;
+use super::auth::AdminUserIdentity;
 
 #[utoipa::path(
     get,
@@ -44,7 +44,7 @@ where
 )]
 pub async fn admin_options_update(
     Path(name): Path<String>,
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     State(app_state): State<AppState>,
     DbConn(mut conn): DbConn,
     raw_body: axum::body::Bytes,
@@ -69,7 +69,7 @@ pub async fn admin_options_update(
         }
     };
 
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -98,11 +98,11 @@ pub async fn admin_options_update(
 )]
 pub async fn admin_options_delete(
     Path(name): Path<String>,
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     State(app_state): State<AppState>,
     DbConn(mut conn): DbConn,
 ) -> Result<AppJson<SafeHavenOptions>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 

--- a/backend/src/api/admin/users.rs
+++ b/backend/src/api/admin/users.rs
@@ -6,7 +6,7 @@ use crate::{
     models::user::{NewOrUpdatedUser, User},
 };
 
-use super::AdminUserTokenClaims;
+use super::auth::AdminUserIdentity;
 
 #[utoipa::path(
     get,
@@ -17,10 +17,10 @@ use super::AdminUserTokenClaims;
     )
 )]
 pub async fn admin_users_list(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
 ) -> Result<AppJson<Vec<User>>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -37,11 +37,11 @@ pub async fn admin_users_list(
     )
 )]
 pub async fn admin_user_new(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Json(new_user): Json<NewOrUpdatedUser>,
 ) -> Result<AppJson<User>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -61,11 +61,11 @@ pub async fn admin_user_new(
     )
 )]
 pub async fn admin_user_get(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
 ) -> Result<AppJson<User>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -83,17 +83,17 @@ pub async fn admin_user_get(
     )
 )]
 pub async fn admin_user_change_self_password(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Json(user_with_changed_password): Json<NewOrUpdatedUser>,
 ) -> Result<AppJson<User>, AppError> {
-    if user_with_changed_password.name != token.username
-        || user_with_changed_password.is_admin != token.is_admin
+    if user_with_changed_password.name != user.username
+        || user_with_changed_password.is_admin != user.is_admin
     {
         return Err(AppError::Unauthorized);
     }
     Ok(AppJson(
-        User::update_user(token.admin_id, user_with_changed_password, &mut conn).await?,
+        User::update_user(user.admin_id, user_with_changed_password, &mut conn).await?,
     ))
 }
 
@@ -111,12 +111,12 @@ pub async fn admin_user_change_self_password(
     )
 )]
 pub async fn admin_user_update(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
     Json(updated_user): Json<NewOrUpdatedUser>,
 ) -> Result<AppJson<User>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 
@@ -138,11 +138,11 @@ pub async fn admin_user_update(
     )
 )]
 pub async fn admin_user_delete(
-    token: AdminUserTokenClaims,
+    user: AdminUserIdentity,
     DbConn(mut conn): DbConn,
     Path(id): Path<Uuid>,
 ) -> Result<AppJson<()>, AppError> {
-    if !token.is_admin {
+    if !user.is_admin {
         return Err(AppError::Unauthorized);
     }
 

--- a/backend/src/api/root.rs
+++ b/backend/src/api/root.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/status", get(status))
-        .route("/bootstrap/:token", get(boostrap))
+        .route("/bootstrap/:token", get(bootstrap))
 }
 
 #[derive(Serialize, ToSchema)]
@@ -89,7 +89,7 @@ pub struct BootstrapQueryParams {
         (status = 200, description = "Bootstraping data", body = BootstrapResponse)
     )
 )]
-async fn boostrap(
+async fn bootstrap(
     State(app_state): State<AppState>,
     Path(token): Path<String>,
     Query(query): Query<BootstrapQueryParams>,
@@ -103,7 +103,7 @@ async fn boostrap(
 
     tracing::trace!("Bootstrapping: found access token");
 
-    let signed_token = app_state.generate_token(MapUserTokenClaims {
+    let signed_token = app_state.generate_refresh_token(MapUserTokenClaims {
         iat: Utc::now().timestamp() as usize,
         exp: (Utc::now() + TimeDelta::try_minutes(5).expect("valid duration")).timestamp() as usize,
         perms: perms.clone(),

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -3,7 +3,7 @@ use crate::{
         admin::{
             self,
             entities::{AdminEntityWithRelations, AdminSearchRequest},
-            AdminUserTokenClaims, LoginRequest, LoginResponse,
+            AdminUserIdentity, LoginRequest, LoginResponse,
         },
         map::{
             self, FetchedEntity, NewCommentRequest, NewEntityRequest,
@@ -45,7 +45,7 @@ use utoipa::OpenApi;
 #[openapi(
     paths(
         root::status,
-        root::boostrap,
+        root::bootstrap,
         // map
         map::viewer_view_request,
         map::viewer_search_request,
@@ -120,7 +120,7 @@ use utoipa::OpenApi;
         // general
         ErrorResponse,
         // admin
-        AdminUserTokenClaims,
+        AdminUserIdentity,
         // stats
         HomePageStats,
         // root

--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,7 @@
 
             # When modifying cargo dependencies, replace the hash with pkgs.lib.fakeSha256
             # then run `nix build .#backend`. Use the hash in the error to replace the value.
-            cargoSha256 = "sha256-DK0wLCVn00ltGRYzAVvWGImQBAb+UyjAjJW+s5AdE0k=";
+            cargoSha256 = "sha256-HS+jnIZQ69TDxIu0xHRIAtlS7my9Jz27UH2qfgKu0XY=";
           };
 
         # Frontend derivation

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1728,7 +1728,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AdminUserTokenClaims"
+                  "$ref": "#/components/schemas/AdminUserIdentity"
                 }
               }
             }
@@ -1762,15 +1762,7 @@
         },
         "responses": {
           "200": {
-            "description": "Login",
-            "headers": {
-              "Set-Cookie": {
-                "schema": {
-                  "$ref": "#/components/schemas/CookieJar"
-                },
-                "description": "Cookie jar with auth cookie inside"
-              }
-            },
+            "description": "Login and set cookies",
             "content": {
               "application/json": {
                 "schema": {
@@ -2388,7 +2380,7 @@
         "tags": [
           "root"
         ],
-        "operationId": "boostrap",
+        "operationId": "bootstrap",
         "parameters": [
           {
             "name": "token",
@@ -3161,27 +3153,17 @@
           }
         }
       },
-      "AdminUserTokenClaims": {
+      "AdminUserIdentity": {
         "type": "object",
         "required": [
           "admin_id",
           "username",
-          "is_admin",
-          "exp",
-          "iat"
+          "is_admin"
         ],
         "properties": {
           "admin_id": {
             "type": "string",
             "format": "uuid"
-          },
-          "exp": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "iat": {
-            "type": "integer",
-            "minimum": 0
           },
           "is_admin": {
             "type": "boolean"


### PR DESCRIPTION
- introduce an API boundary between jwt claims and authorization
- move authentication code to a separate module