### PR TITLE
backend: fix logout

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_derive",
+ "cookie",
  "crc32fast",
  "figment",
  "jsonwebtoken",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,6 +22,7 @@ scrypt = "0.11"
 time = "0.3.36"
 chrono = { version = "0.4", features = ["serde"] }
 axum = { version = "0.7", features = ["macros", "multipart"] }
+cookie = "0.18.1"
 axum-extra = { version = "0.9", features = ["typed-header", "cookie"] }
 tokio = { version = "1.36", features = ["full"] }
 figment = { version = "0.10", features = ["toml", "env"] }

--- a/backend/src/api/admin.rs
+++ b/backend/src/api/admin.rs
@@ -210,6 +210,6 @@ async fn admin_login(
         (status = 404, description = "User or password not found", body = ErrorResponse),
     )
 )]
-async fn admin_logout(cookies: CookieJar) -> Response {
-    auth::expire_cookies(cookies).into_response()
+async fn admin_logout(State(app_state): State<AppState>, cookies: CookieJar) -> Response {
+    auth::expire_cookies(&app_state, cookies).into_response()
 }


### PR DESCRIPTION
- fixes a regression introduced by 90b973eb7600208cebc0021501b2e03ffcee4a0d: cookie path and properties are missing from the client provided cookie jar, and need to be properly set by the server
- when `secure_cookie` is set, set the secure cookie flag needs on cookie deletion too